### PR TITLE
Fix manifest for Android PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <!-- PWA Manifest & Theme -->
     <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#16213e">
+    <meta name="mobile-web-app-capable" content="yes">
     
     <!-- iOS Specific Tags -->
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,3 @@
     }
   ]
 }
-```
-
-**Cambio importante:** He cambiado `"start_url": "index.html"` por `"start_url": "."`. Esto a veces ayuda a que los navegadores encuentren la página principal de forma más fiable.


### PR DESCRIPTION
## Summary
- clean up `manifest.json` to ensure it's valid JSON
- add `<meta name="mobile-web-app-capable" content="yes">` for Android

## Testing
- `python3 -m json.tool manifest.json`


------
https://chatgpt.com/codex/tasks/task_e_686b0e10bbd883339c0b128f2b9c7bac