### PR TITLE
Add theme and vehicle options

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <!-- PWA Manifest & Theme -->
     <link rel="manifest" href="manifest.json">
     <meta name="theme-color" content="#16213e">
+    <meta name="mobile-web-app-capable" content="yes">
     
     <!-- iOS Specific Tags -->
     <meta name="apple-mobile-web-app-capable" content="yes">
@@ -30,6 +31,14 @@
             --info-color: #3498db;
             --font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
         }
+        @media (prefers-color-scheme: light) {
+            :root {
+                --primary-bg: #f5f5f5;
+                --secondary-bg: #ffffff;
+                --card-bg: #e0e0e0;
+                --text-color: #333333;
+            }
+        }
         * { margin: 0; padding: 0; box-sizing: border-box; }
         html, body { font-family: var(--font-family); background-color: var(--primary-bg); color: var(--text-color); height: 100%; overscroll-behavior-y: contain; }
         #app-container { display: flex; flex-direction: column; height: 100vh; max-width: 800px; margin: 0 auto; background-color: var(--secondary-bg); }
@@ -46,6 +55,7 @@
         .form-group { margin-bottom: 1.5rem; }
         .form-group label { display: block; margin-bottom: 0.5rem; font-weight: bold; color: var(--text-color); }
         .form-group input { width: 100%; padding: 0.8rem; background-color: var(--primary-bg); border: 1px solid var(--primary-accent); border-radius: 8px; color: var(--text-color); font-size: 1rem; }
+        .form-group select { width: 100%; padding: 0.8rem; background-color: var(--primary-bg); border: 1px solid var(--primary-accent); border-radius: 8px; color: var(--text-color); font-size: 1rem; }
         .btn { display: block; width: 100%; padding: 1rem; background-color: var(--secondary-accent); color: white; border: none; border-radius: 8px; font-size: 1.1rem; font-weight: bold; cursor: pointer; text-align: center; transition: background-color 0.3s; }
         .btn:hover { background-color: #d83a56; }
         .btn-secondary { background-color: var(--info-color); }
@@ -109,6 +119,18 @@
                             <div class="form-group">
                                 <label for="ano">Año</label>
                                 <input type="number" id="ano" required placeholder="Ej: 2020">
+                            </div>
+                            <div class="form-group">
+                                <label for="color">Color del Vehículo</label>
+                                <input type="color" id="color" value="#0f3460">
+                            </div>
+                            <div class="form-group">
+                                <label for="tipo">Tipo de Vehículo</label>
+                                <select id="tipo">
+                                    <option value="auto">Automóvil</option>
+                                    <option value="moto">Moto</option>
+                                    <option value="camioneta">Camioneta</option>
+                                </select>
                             </div>
                             <div class="form-group">
                                 <label for="kilometraje-inicial">Kilometraje Actual (km)</label>
@@ -232,6 +254,21 @@
                             <label for="settings-ano">Año</label>
                             <input type="number" id="settings-ano" required>
                         </div>
+                        <div class="form-group">
+                            <label for="settings-color">Color del Vehículo</label>
+                            <input type="color" id="settings-color">
+                        </div>
+                        <div class="form-group">
+                            <label for="settings-tipo">Tipo de Vehículo</label>
+                            <select id="settings-tipo">
+                                <option value="auto">Automóvil</option>
+                                <option value="moto">Moto</option>
+                                <option value="camioneta">Camioneta</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label><input type="checkbox" id="settings-use-color"> Usar colores del vehículo</label>
+                        </div>
                         
                         <h3>Fechas Legales</h3>
                         <div class="form-group">
@@ -329,7 +366,7 @@
     
     <!-- Update Date Modal -->
     <div id="modal-update-date" class="modal">
-        <div class.modal-content">
+        <div class="modal-content">
             <span class="modal-close" onclick="App.closeModal('modal-update-date')">&times;</span>
             <h3 id="update-date-title"></h3>
             <form id="form-update-date">
@@ -366,9 +403,15 @@
                             .catch(err => console.log('Error al registrar Service Worker:', err));
                     });
                 }
+                if ('Notification' in window && Notification.permission === 'default') {
+                    Notification.requestPermission();
+                }
                 document.addEventListener('DOMContentLoaded', () => {
                     this.loadData();
+                    this.applyTheme();
                     this.attachEventListeners();
+                    const mql = window.matchMedia('(prefers-color-scheme: dark)');
+                    mql.addEventListener('change', () => this.applyTheme());
                     if (!this.data) {
                         this.showSection('initial-setup');
                         document.getElementById('app-nav').style.display = 'none';
@@ -379,9 +422,36 @@
                     }
                 });
             },
-            loadData() { const storedData = localStorage.getItem(this.DB_KEY); if (storedData) { this.data = JSON.parse(storedData); } },
+            loadData() {
+                const storedData = localStorage.getItem(this.DB_KEY);
+                if (storedData) {
+                    this.data = JSON.parse(storedData);
+                    if (!this.data.vehiculo.color) this.data.vehiculo.color = '#0f3460';
+                    if (!this.data.vehiculo.tipo) this.data.vehiculo.tipo = 'auto';
+                    if (typeof this.data.useColorTheme === 'undefined') this.data.useColorTheme = true;
+                    if (!this.data.mantenimientoAvisado) this.data.mantenimientoAvisado = 0;
+                }
+            },
             saveData() { if (this.data) { localStorage.setItem(this.DB_KEY, JSON.stringify(this.data)); } },
-            renderAll() { if (!this.data) return; this.renderDashboard(); this.renderHistory(); this.renderTips(); this.renderSettings(); },
+            applyTheme() {
+                const root = document.documentElement;
+                const metaTheme = document.querySelector('meta[name="theme-color"]');
+                if (this.data && this.data.useColorTheme && this.data.vehiculo.color) {
+                    root.style.setProperty('--primary-accent', this.data.vehiculo.color);
+                    if (metaTheme) metaTheme.setAttribute('content', this.data.vehiculo.color);
+                } else {
+                    root.style.setProperty('--primary-accent', '#0f3460');
+                    if (metaTheme) metaTheme.setAttribute('content', '#16213e');
+                }
+            },
+            renderAll() {
+                if (!this.data) return;
+                this.applyTheme();
+                this.renderDashboard();
+                this.renderHistory();
+                this.renderTips();
+                this.renderSettings();
+            },
             attachEventListeners() {
                 document.getElementById('setup-form').addEventListener('submit', this.handleSetupSubmit.bind(this));
                 document.getElementById('app-nav').addEventListener('click', this.handleNavClick.bind(this));
@@ -411,14 +481,19 @@
                         marca: document.getElementById('marca').value,
                         modelo: document.getElementById('modelo').value,
                         ano: parseInt(document.getElementById('ano').value),
+                        color: document.getElementById('color').value,
+                        tipo: document.getElementById('tipo').value,
                         kilometraje: parseInt(document.getElementById('kilometraje-inicial').value),
                         intervaloMantenimiento: parseInt(document.getElementById('intervalo').value),
                         ultimoMantenimiento: parseInt(document.getElementById('kilometraje-inicial').value)
                     },
                     fechas: { soat: document.getElementById('soat').value, revision: document.getElementById('revision').value },
-                    historial: []
+                    historial: [],
+                    useColorTheme: true,
+                    mantenimientoAvisado: 0
                 };
                 this.saveData();
+                this.applyTheme();
                 this.renderAll();
                 this.showSection('dashboard');
                 document.getElementById('app-nav').style.display = 'flex';
@@ -429,10 +504,26 @@
                 document.getElementById('km-actual').textContent = vehiculo.kilometraje.toLocaleString('es-ES');
                 const kmDesdeMantenimiento = vehiculo.kilometraje - vehiculo.ultimoMantenimiento;
                 const kmParaMantenimiento = vehiculo.intervaloMantenimiento - kmDesdeMantenimiento;
-                document.getElementById('km-proximo-mantenimiento').textContent = kmParaMantenimiento.toLocaleString('es-ES');
+                if (kmParaMantenimiento >= 0) {
+                    document.getElementById('km-proximo-mantenimiento').textContent = kmParaMantenimiento.toLocaleString('es-ES');
+                } else {
+                    document.getElementById('km-proximo-mantenimiento').textContent = `Vencido hace ${Math.abs(kmParaMantenimiento).toLocaleString('es-ES')}`;
+                    if (this.data.mantenimientoAvisado !== vehiculo.ultimoMantenimiento) {
+                        if (confirm(`El mantenimiento se venció hace ${Math.abs(kmParaMantenimiento)} km. ¿Ya realizaste el mantenimiento?`)) {
+                            const realizado = parseInt(prompt('¿En qué kilometraje se realizó?', vehiculo.kilometraje));
+                            if (realizado && !isNaN(realizado)) {
+                                this.data.vehiculo.ultimoMantenimiento = realizado;
+                                if (realizado > this.data.vehiculo.kilometraje) this.data.vehiculo.kilometraje = realizado;
+                                this.saveData();
+                            }
+                        }
+                        this.data.mantenimientoAvisado = vehiculo.ultimoMantenimiento;
+                    }
+                }
                 this.updateDateStatus('soat', fechas.soat);
                 this.updateDateStatus('revision', fechas.revision);
                 this.renderRandomTip();
+                this.checkNotifications();
             },
             updateDateStatus(type, dateString) {
                 const statusEl = document.getElementById(`${type}-status`);
@@ -470,16 +561,64 @@
                 this.saveData(); this.renderHistory(); this.renderDashboard(); this.closeModal('modal-add-service');
             },
             renderTips() { const container = document.getElementById('tips-container'); container.innerHTML = ''; for (const category in this.tips) { const categoryDiv = document.createElement('div'); categoryDiv.className = 'tip-category'; let tipsHtml = `<div class="card"><h3>${category}</h3>`; this.tips[category].forEach(tip => { tipsHtml += `<div class="tip-item">${tip}</div>`; }); tipsHtml += '</div>'; categoryDiv.innerHTML = tipsHtml; container.appendChild(categoryDiv); } },
-            renderSettings() { const { vehiculo, fechas } = this.data; document.getElementById('settings-marca').value = vehiculo.marca; document.getElementById('settings-modelo').value = vehiculo.modelo; document.getElementById('settings-ano').value = vehiculo.ano; document.getElementById('settings-soat').value = fechas.soat; document.getElementById('settings-revision').value = fechas.revision; document.getElementById('settings-intervalo').value = vehiculo.intervaloMantenimiento; },
+            checkNotifications() {
+                if (!('Notification' in window) || Notification.permission !== 'granted' || !this.data) return;
+                const today = new Date();
+                today.setHours(0,0,0,0);
+                ['soat','revision'].forEach(type => {
+                    const dateStr = this.data.fechas[type];
+                    if (!dateStr) return;
+                    const exp = new Date(dateStr + 'T00:00:00');
+                    const diffDays = Math.floor((exp - today) / (1000*60*60*24));
+                    const name = type === 'soat' ? 'SOAT' : 'Revisión Técnica';
+                    const notify = msg => {
+                        if (navigator.serviceWorker && navigator.serviceWorker.getRegistration) {
+                            navigator.serviceWorker.getRegistration().then(reg => {
+                                if (reg) { reg.showNotification(name, { body: msg }); }
+                                else { new Notification(name, { body: msg }); }
+                            });
+                        } else {
+                            new Notification(name, { body: msg });
+                        }
+                    };
+                    if ([30,7,1,0].includes(diffDays)) {
+                        const messages = {
+                            30: `Tu ${name} vence en 30 días.`,
+                            7: `Tu ${name} vence en 7 días.`,
+                            1: `Tu ${name} vence mañana.`,
+                            0: `Tu ${name} vence hoy.`
+                        };
+                        notify(messages[diffDays]);
+                    } else if (diffDays < 0 && diffDays % 3 === 0) {
+                        notify(`Tu ${name} está vencido hace ${Math.abs(diffDays)} días.`);
+                    }
+                });
+            },
+            renderSettings() {
+                const { vehiculo, fechas, useColorTheme } = this.data;
+                document.getElementById('settings-marca').value = vehiculo.marca;
+                document.getElementById('settings-modelo').value = vehiculo.modelo;
+                document.getElementById('settings-ano').value = vehiculo.ano;
+                document.getElementById('settings-color').value = vehiculo.color;
+                document.getElementById('settings-tipo').value = vehiculo.tipo;
+                document.getElementById('settings-soat').value = fechas.soat;
+                document.getElementById('settings-revision').value = fechas.revision;
+                document.getElementById('settings-intervalo').value = vehiculo.intervaloMantenimiento;
+                document.getElementById('settings-use-color').checked = !!useColorTheme;
+            },
             handleSettingsSave(e) {
                 e.preventDefault();
                 this.data.vehiculo.marca = document.getElementById('settings-marca').value;
                 this.data.vehiculo.modelo = document.getElementById('settings-modelo').value;
                 this.data.vehiculo.ano = parseInt(document.getElementById('settings-ano').value);
+                this.data.vehiculo.color = document.getElementById('settings-color').value;
+                this.data.vehiculo.tipo = document.getElementById('settings-tipo').value;
                 this.data.fechas.soat = document.getElementById('settings-soat').value;
                 this.data.fechas.revision = document.getElementById('settings-revision').value;
                 this.data.vehiculo.intervaloMantenimiento = parseInt(document.getElementById('settings-intervalo').value);
+                this.data.useColorTheme = document.getElementById('settings-use-color').checked;
                 this.saveData();
+                this.applyTheme();
                 this.renderAll();
                 alert('Configuración guardada con éxito.');
                 this.showSection('dashboard');

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,3 @@
     }
   ]
 }
-```
-
-**Cambio importante:** He cambiado `"start_url": "index.html"` por `"start_url": "."`. Esto a veces ayuda a que los navegadores encuentren la página principal de forma más fiable.


### PR DESCRIPTION
## Summary
- update CSS to react to system light/dark mode
- ask for vehicle color and type during setup
- allow configuring color-based theme in settings
- apply accent color according to vehicle color
- show prompt when maintenance is overdue in km

## Testing
- `python3 -m json.tool manifest.json`


------
https://chatgpt.com/codex/tasks/task_e_686b0e10bbd883339c0b128f2b9c7bac